### PR TITLE
Do not use the same byte for entire key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -280,7 +280,7 @@ const keyGen = length => {
     const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ9'
     let key = '';
     while (key.length < length) {
-        const byte = crypto.randomBytes(1)
+        let byte = crypto.randomBytes(1)
         if (byte[0] < 243) {
             key += charset.charAt(byte[0] % 27);
         }


### PR DESCRIPTION
* this is a flaw that limits the keygen to only 27 possible keys.

Hope this helps!