### PR TITLE
Added the future to use alternative attachToTangle functions

### DIFF
--- a/lib/mam.client.js
+++ b/lib/mam.client.js
@@ -24375,7 +24375,7 @@ var fetchSingle = function () {
                         if (mode === 'private' || mode === 'restricted') {
                             address = hash(root, rounds);
                         }
-                        _composeAPI = composeAPI({ provider, attachToTangle }), findTransactions = _composeAPI.findTransactions;
+                        _composeAPI = composeAPI({ provider }), findTransactions = _composeAPI.findTransactions;
                         _context2.next = 5;
                         return findTransactions({
                             addresses: [address]
@@ -24527,7 +24527,7 @@ var txHashesToMessages = function () {
                             }
                         };
 
-                        _composeAPI2 = composeAPI({ provider, attachToTangle }), getTransactionObjects = _composeAPI2.getTransactionObjects;
+                        _composeAPI2 = composeAPI({ provider }), getTransactionObjects = _composeAPI2.getTransactionObjects;
                         _context4.next = 5;
                         return getTransactionObjects(hashes);
 

--- a/lib/mam.client.js
+++ b/lib/mam.client.js
@@ -24170,7 +24170,7 @@ var _require3 = __webpack_require__(528),
 
 
 var provider = null;
-var attachToTangle = null;
+var overrideAttachToTangle = null;
 var Mam = {};
 
 /**
@@ -24178,16 +24178,18 @@ var Mam = {};
  * @param  {object} externalIOTA
  * @param  {string} seed
  * @param  {integer} security
+ * @param  {function} externalAttachToTangle
  */
-var init = function init(externalProvider, externalAttachToTangle) {
-    var seed = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : keyGen(81);
-    var security = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 2;
+var init = function init(externalProvider) {
+    var seed = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : keyGen(81);
+    var security = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 2;
+    var externalAttachToTangle = arguments[3];
 
     // Set IOTA provider
     provider = externalProvider;
 
     // Set alternative attachToTangle function
-    attachToTangle = externalAttachToTangle;
+    overrideAttachToTangle = externalAttachToTangle;
 
     // Setup Personal Channel
     var channel = {
@@ -24298,7 +24300,7 @@ var fetch = function () {
             while (1) {
                 switch (_context.prev = _context.next) {
                     case 0:
-                        client = createHttpClient({ provider, attachToTangle });
+                        client = createHttpClient({ provider, attachToTangle: overrideAttachToTangle });
                         _context.next = 3;
                         return createContext();
 
@@ -24569,7 +24571,7 @@ var attach = function () {
                             message: trytes
                         }];
                         _context5.prev = 1;
-                        _composeAPI3 = composeAPI({ provider, attachToTangle }), prepareTransfers = _composeAPI3.prepareTransfers, sendTrytes = _composeAPI3.sendTrytes;
+                        _composeAPI3 = composeAPI({ provider, attachToTangle: overrideAttachToTangle }), prepareTransfers = _composeAPI3.prepareTransfers, sendTrytes = _composeAPI3.sendTrytes;
                         _context5.next = 5;
                         return prepareTransfers('9'.repeat(81), transfers, {});
 

--- a/lib/mam.client.js
+++ b/lib/mam.client.js
@@ -24170,6 +24170,7 @@ var _require3 = __webpack_require__(528),
 
 
 var provider = null;
+var attachToTangle = null;
 var Mam = {};
 
 /**
@@ -24178,12 +24179,15 @@ var Mam = {};
  * @param  {string} seed
  * @param  {integer} security
  */
-var init = function init(externalProvider) {
-    var seed = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : keyGen(81);
-    var security = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 2;
+var init = function init(externalProvider, externalAttachToTangle) {
+    var seed = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : keyGen(81);
+    var security = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : 2;
 
     // Set IOTA provider
     provider = externalProvider;
+
+    // Set alternative attachToTangle function
+    attachToTangle = externalAttachToTangle;
 
     // Setup Personal Channel
     var channel = {
@@ -24294,7 +24298,7 @@ var fetch = function () {
             while (1) {
                 switch (_context.prev = _context.next) {
                     case 0:
-                        client = createHttpClient({ provider });
+                        client = createHttpClient({ provider, attachToTangle });
                         _context.next = 3;
                         return createContext();
 
@@ -24371,7 +24375,7 @@ var fetchSingle = function () {
                         if (mode === 'private' || mode === 'restricted') {
                             address = hash(root, rounds);
                         }
-                        _composeAPI = composeAPI({ provider }), findTransactions = _composeAPI.findTransactions;
+                        _composeAPI = composeAPI({ provider, attachToTangle }), findTransactions = _composeAPI.findTransactions;
                         _context2.next = 5;
                         return findTransactions({
                             addresses: [address]
@@ -24523,7 +24527,7 @@ var txHashesToMessages = function () {
                             }
                         };
 
-                        _composeAPI2 = composeAPI({ provider }), getTransactionObjects = _composeAPI2.getTransactionObjects;
+                        _composeAPI2 = composeAPI({ provider, attachToTangle }), getTransactionObjects = _composeAPI2.getTransactionObjects;
                         _context4.next = 5;
                         return getTransactionObjects(hashes);
 
@@ -24565,7 +24569,7 @@ var attach = function () {
                             message: trytes
                         }];
                         _context5.prev = 1;
-                        _composeAPI3 = composeAPI({ provider }), prepareTransfers = _composeAPI3.prepareTransfers, sendTrytes = _composeAPI3.sendTrytes;
+                        _composeAPI3 = composeAPI({ provider, attachToTangle }), prepareTransfers = _composeAPI3.prepareTransfers, sendTrytes = _composeAPI3.sendTrytes;
                         _context5.next = 5;
                         return prepareTransfers('9'.repeat(81), transfers, {});
 

--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ const fetchSingle = async (root, mode, sidekey, rounds = 81) => {
     if (mode === 'private' || mode === 'restricted') {
         address = hash(root, rounds)
     }
-    const { findTransactions } = composeAPI({ provider, attachToTangle })
+    const { findTransactions } = composeAPI({ provider })
     const hashes = await findTransactions({
         addresses: [address]
     })
@@ -216,7 +216,7 @@ const txHashesToMessages = async hashes => {
                 .reduce((acc, n) => acc + n[1], '')
         }
     }
-    const { getTransactionObjects } = composeAPI({ provider, attachToTangle })
+    const { getTransactionObjects } = composeAPI({ provider })
     const objs = await getTransactionObjects(
         hashes
     )

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ const { createContext, Reader, Mode } = require('../lib/mam')
 
 // Setup Provider
 let provider = null;
-let attachToTangle = null;
+let overrideAttachToTangle = null;
 let Mam = {}
 
 /**
@@ -17,13 +17,14 @@ let Mam = {}
  * @param  {object} externalIOTA
  * @param  {string} seed
  * @param  {integer} security
+ * @param  {function} externalAttachToTangle
  */
-const init = (externalProvider, externalAttachToTangle, seed = keyGen(81), security = 2) => {
+const init = (externalProvider, seed = keyGen(81), security = 2, externalAttachToTangle) => {
     // Set IOTA provider
     provider = externalProvider
 
     // Set alternative attachToTangle function
-    attachToTangle = externalAttachToTangle
+    overrideAttachToTangle = externalAttachToTangle
 
     // Setup Personal Channel
     const channel = {
@@ -128,7 +129,7 @@ const decode = (payload, sidekey, root) => {
 }
 
 const fetch = async (root, selectedMode, sidekey, callback) => {
-    let client = createHttpClient({ provider, attachToTangle })
+    let client = createHttpClient({ provider, attachToTangle : overrideAttachToTangle })
     let ctx = await createContext()
     const messages = []
     const mode = selectedMode === 'public' ? Mode.Public : Mode.Old
@@ -234,7 +235,7 @@ const attach = async (trytes, root, depth = 3, mwm = 9) => {
         }
     ]
     try {
-        const { prepareTransfers, sendTrytes } = composeAPI({ provider, attachToTangle })
+        const { prepareTransfers, sendTrytes } = composeAPI({ provider, attachToTangle : overrideAttachToTangle })
 
         const trytes = await prepareTransfers('9'.repeat(81), transfers, {})
 


### PR DESCRIPTION
# Description
This enhancement added the future to use alternative attachToTangle functions (e.g. to use another Node to do the PoW or use a PoW service)

## Type of change
* Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?
* mam.client.js/example/publishAndFetchPublic.js (with and without alternative attachToTangle function)

# Checklist:
* [x]   My code follows the style guidelines for this project
* [x]   I have performed a self-review of my own code
* [x]   New and existing unit tests pass locally with my changes