### PR TITLE
Fixed bundle sorting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -208,7 +208,7 @@ const txHashesToMessages = async hashes => {
             let l = bundles[bundle]
             delete bundles[bundle]
             return l
-                .sort((a, b) => b[0] < a[0])
+                .sort((a, b) => a[0] - b[0])
                 .reduce((acc, n) => acc + n[1], '')
         }
     }


### PR DESCRIPTION
The bundle sorting used b < a as its comparison which does nothing, so when bundles tried to decode in rust lib they failed. Decoding might have worked sometimes if the bundles by luck came from the node in the correct order.

This code does not sort.

```
[5, 1, 2, 8, 3, 5, 3, 2].sort((a, b) => b < a)
(8) [5, 1, 2, 8, 3, 5, 3, 2]
```
Changed to a - b

```
[5, 1, 2, 8, 3, 5, 3, 2].sort((a, b) => a - b)
(8) [1, 2, 2, 3, 3, 5, 5, 8]
```