### PR TITLE
Updated fetchSingle to use new Reader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,11 +158,11 @@ const fetch = async (root, selectedMode, sidekey, callback, limit) => {
 }
 
 const fetchSingle = async (root, selectedMode, sidekey) => {
-    const response = await fetch(root, selectedMode, sidekey, undefined, 1);
+    const response = await fetch(root, selectedMode, sidekey, undefined, 1)
     return response && response.nextRoot ? {
         payload: response.messages && response.messages.length === 1 ? response.messages[0] : undefined,
         nextRoot: response.nextRoot
-    } : response;
+    } : response
 }
 
 const listen = (channel, callback) => {

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ const fetch = async (root, selectedMode, sidekey, callback, limit) => {
     const mode = selectedMode === 'public' ? Mode.Public : Mode.Old
     let hasMessage = false
     let nextRoot = root
-    let localLimit = !!limit ? limit : Number.MAX_SAFE_INTEGER;
+    let localLimit = limit || Number.MAX_SAFE_INTEGER;
 
     try {
         do {

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,7 @@ const fetch = async (root, selectedMode, sidekey, callback, limit) => {
     const mode = selectedMode === 'public' ? Mode.Public : Mode.Old
     let hasMessage = false
     let nextRoot = root
-    let localLimit = limit || Number.MAX_SAFE_INTEGER;
+    let localLimit = limit || Math.pow(2, 53) - 1;
 
     try {
         do {


### PR DESCRIPTION
Updated fetchSingle to use the new Reader class the same as fetch. 

The old fetchSingle method was very unstable and failed to decode the messages without any sensible feedback as to what the failure was.